### PR TITLE
accept readDate as integer or Date

### DIFF
--- a/logger/index.js
+++ b/logger/index.js
@@ -126,8 +126,8 @@ transmitter.on('glucose', glucose => {
     const extraData = JSON.stringify(extra);
   const entry = [{
       'device': 'DexcomR4',
-      'date': glucose.readDate,
-      'dateString': new Date(glucose.readDate).toISOString(),
+      'date': d.getTime(),
+      'dateString': d.toISOString(),
       //'sgv': Math.round(glucose.unfiltered/1000),
       'sgv': glucose.glucose,
       'direction': 'None',


### PR DESCRIPTION
This change accepts `readDate` in the `glucose` message as either milliseconds since epoch, or a JavaScript Date object. To support change in messaging interface in https://github.com/xdrip-js/xdrip-js/pull/62.