### PR TITLE
Added API_SECRET headers for curl calls to NightScout

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -267,7 +267,7 @@ function ClearCalibrationCache()
 # check UTC to begin with and use UTC flag for any curls
 function check_utc()
 {
-  curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?count=1&find\[created_at\]\[\$gte\]=$(date -d "2400 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null  > ${LDIR}/testUTC.json  
+  curl --compressed -m 30 -H "API-SECRET: ${API_SECRET}" "${NIGHTSCOUT_HOST}/api/v1/treatments.json?count=1&find\[created_at\]\[\$gte\]=$(date -d "2400 hours ago" -Ihours -u)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null  > ${LDIR}/testUTC.json  
   if [ $? == 0 ]; then
     createdAt=$(jq ".[0].created_at" ${LDIR}/testUTC.json)
     createdAt="${createdAt%\"}"
@@ -357,7 +357,7 @@ function check_sensor_start()
 
   file="${LDIR}/nightscout_sensor_start_treatment.json"
   rm -f $file
-  curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "3 hours ago" -Ihours $UTC)&find\[eventType\]\[\$regex\]=Sensor.Start" 2>/dev/null > $file
+  curl --compressed -m 30 -H "API-SECRET: ${API_SECRET}" "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "3 hours ago" -Ihours $UTC)&find\[eventType\]\[\$regex\]=Sensor.Start" 2>/dev/null > $file
   if [ $? == 0 ]; then
     len=$(jq '. | length' $file)
     index=$(bc <<< "$len - 1")
@@ -394,7 +394,7 @@ function check_sensor_start()
 # calibrate after 15 minutes of sensor change time entered in NS
 function check_sensor_change()
 {
-  curl --compressed -m 30 "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" -Iminutes $UTC)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
+  curl --compressed -m 30 -H "API-SECRET: ${API_SECRET}" "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" -Iminutes $UTC)&find\[eventType\]\[\$regex\]=Sensor.Change" 2>/dev/null | grep "Sensor Change"
   if [ $? == 0 ]; then
     log "sensor change within last 15 minutes - clearing calibration files"
     ClearCalibrationInput


### PR DESCRIPTION
Fixes errors with Logger not being able to communicate correctly with NightScout due to missing header for the API_SECRET.  Without the header calls result in http 401s.

Example errors from logger-loop.log:
```
jq: error: Cannot index object with number
08/10 09:42:03 You must record a "Sensor Insert" in Nightscout before Logger will run
08/10 09:42:03 If you are offline at the moment (no internet) then this warning is OK
[{"device":"xdripjs://edisonaps","xdripjs": {"sessionStart":0,"state":35,"txStatus":0,"stateString":"Needs NS CGM Sensor Insert","stateStringShort":"Needs NS CGM Sensor Insert","txId":"######","mode":"not-expired","timestamp":1533912122322}, "created_at":"2018-08-10T14:42:02.355Z"}]
[{"device":"xdripjs://edisonaps","xdripjs":{"sessionStart":0,"state":35,"txStatus":0,"stateString":"Needs NS CGM Sensor Insert","stateStringShort":"Needs NS CGM Sensor Insert","txId":"######","mode":"not-expired","timestamp":1533912122322},"created_at":"2018-08-10T14:42:02.355Z","_id":"5b6da43e5dad43001398354c"}]
```
