### PR TITLE
Fix errors in apply_lsr_calibration() for not-expired mode when calibration records do not exist

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -848,8 +848,14 @@ function apply_lsr_calibration()
       post_cgm_ns_pill
       remove_dexcom_bt_pair
       exit
+    else
+      if [ "$mode" == "not-expired" ]; then
+        # exit as there is nothing to calibrate without calibration-linear.json?
+        log "no calibration records (mode: not-expired)"
+        exit
+      fi
     fi
-  fi
+  fi   
 
   # $raw is either unfiltered or filtered value from g5
   # based upon glucoseType variable at top of script

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -752,7 +752,7 @@ function check_ns_calibration()
   if [ $found_meterbg == false ]; then
     # can't use the Sensor insert UTC determination for BG since they can
     # be entered in either UTC or local time depending on how they were entered.
-    curl --compressed -m 30 "${ns_url}/api/v1/treatments.json?find\[eventType\]\[\$regex\]=Check&count=1" 2>/dev/null > $METERBG_NS_RAW
+    curl --compressed -m 30 -H "API-SECRET: ${API_SECRET}" "${ns_url}/api/v1/treatments.json?find\[eventType\]\[\$regex\]=Check&count=1" 2>/dev/null > $METERBG_NS_RAW
     createdAt=$(jq -r ".[0].created_at" $METERBG_NS_RAW)
     secNow=`date +%s`
     secThen=`date +%s --date=$createdAt`


### PR DESCRIPTION
Resolves issue with the following errors:
```
  08/16 19:36:35 Calling expired tx lsr calcs (after posting) -allows mode switches / comparisons
  (standard_in) 1: syntax error
  (standard_in) 1: syntax error
  08/16 19:36:35 After calibration calibratedBG =, slope=, yIntercept=, filtered=162.282, unfiltered=171.496, raw=171.496
  08/16 19:36:35 numCalibrations=, calibrationType=, c=
  (standard_in) 1: syntax error
  (standard_in) 1: syntax error
  /usr/local/bin/Logger: line 883: [: too many arguments
  (standard_in) 1: syntax error
  /usr/local/bin/Logger: line 896: [: -eq: unary operator expected
  (standard_in) 1: syntax error
  /usr/local/bin/Logger: line 902: [: -eq: unary operator expected
```