### PR TITLE
 use either old or new filename for pumphistory now, whichever exists

### DIFF
--- a/test/test-pump-history-file.sh
+++ b/test/test-pump-history-file.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function check_dirs()
+{
+  LDIR=~/myopenaps/monitor/xdripjs5
+  OLD_LDIR=~/myopenaps/monitor/logger5
+
+  if [ ! -d ${LDIR} ]; then
+    if [ -d ${OLD_LDIR} ]; then
+      mv ${OLD_LDIR} ${LDIR} 
+    fi
+  fi
+  mkdir -p ${LDIR}
+  mkdir -p ${LDIR}/old-calibrations
+}
+
+check_dirs

--- a/test/test-pump-history-file.sh
+++ b/test/test-pump-history-file.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 
-function check_dirs()
+function testpumphistory()
 {
-  LDIR=~/myopenaps/monitor/xdripjs5
-  OLD_LDIR=~/myopenaps/monitor/logger5
 
-  if [ ! -d ${LDIR} ]; then
-    if [ -d ${OLD_LDIR} ]; then
-      mv ${OLD_LDIR} ${LDIR} 
-    fi
+if [ -e "$HOME/myopenaps/monitor/pumphistory-zoned.json" ]; then
+   echo found first file
+else
+  if [ -e "$HOME/myopenaps/monitor/pumphistory-24h-zoned.json" ]; then
+   echo found second file
   fi
-  mkdir -p ${LDIR}
-  mkdir -p ${LDIR}/old-calibrations
+fi
+
+historyFile="$HOME/myopenaps/monitor/pumphistory-24h-zoned.json"
+if [ ! -e "$historyFile" ]; then
+  echo did not find $historyFile
+else
+  echo found $historyFile
+fi
+
 }
 
-check_dirs
+testpumphistory

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -763,13 +763,20 @@ function check_last_calibration()
 
 function check_pump_history_calibration()
 {
+
   if [ $found_meterbg == false ]; then
-    if [ -e "~/myopenaps/monitor/pumphistory-24h-zoned.json" ]; then
+    historyFile="$HOME/myopenaps/monitor/pumphistory-24h-zoned.json"
+    if [ ! -e "$historyFile" ]; then
+      # support the old file name in case of older version of OpenAPS
+      historyFile="$HOME/myopenaps/monitor/pumphistory-zoned.json"
+    fi
+
+    if [ -e "$historyFile" ]; then
       # look for a bg check from pumphistory (direct from meter->openaps):
       # note: pumphistory may not be loaded by openaps very timely...
       meterbgafter=$(date -d "9 minutes ago" -Iminutes)
       meterjqstr="'.[] | select(._type == \"BGReceived\") | select(.timestamp > \"$meterbgafter\")'"
-      bash -c "jq $meterjqstr ~/myopenaps/monitor/pumphistory-24h-zoned.json" > $METERBG_NS_RAW
+      bash -c "jq $meterjqstr $historyFile" > $METERBG_NS_RAW
       meterbg=$(bash -c "jq .amount $METERBG_NS_RAW | head -1")
       meterbgid=$(bash -c "jq .timestamp $METERBG_NS_RAW | head -1")
       # meter BG from pumphistory doesn't support mmol yet - has no units...

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -893,18 +893,20 @@ function apply_lsr_calibration()
     fi
   else
     if [ "$mode" == "expired" ]; then
-      # exit until we have a valid calibration record
-      log "no valid calibration record yet, exiting ..."
+      # don't exit here because g6 supports no calibration mode now
+      # TODO: determine if g6 and in no-calibration mode somehow and do not set state to First Calibration
+      log "no calibration records (mode: expired)"
       state_id=0x04
       state="First Calibration" ; stateString=$state ; stateStringShort=$state
-      post_cgm_ns_pill
-      remove_dexcom_bt_pair
-      exit
+      #post_cgm_ns_pill
+      #remove_dexcom_bt_pair
+      #exit
     else
       if [ "$mode" == "not-expired" ]; then
         # exit as there is nothing to calibrate without calibration-linear.json?
         log "no calibration records (mode: not-expired)"
-        exit
+	# don't exit here because g6 supports no calibration mode now
+        #exit
       fi
     fi
   fi   


### PR DESCRIPTION
Also do not exit when calibration does not exist (g6)