### PR TITLE
Use oref0-pump-loop plugin to run fakemeter

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1095,12 +1095,6 @@ function process_delta()
     da=$(bc <<< "0 - $da")
   fi
 
-# EYF try
-  if [ $(bc <<< "$dg > 20") -eq 1 -o $(bc <<< "$dg < (0 - 20)") -eq 1 ]; then
-    log "Change to smooth it out some"
-    calibratedBG=$(bc <<< "$calibratedBG - ($dg/2)")
-  fi
-
   if [ $(bc <<< "$dg > $maxDelta") -eq 1 -o $(bc <<< "$dg < (0 - $maxDelta)") -eq 1 ]; then
     log "Change $dg out of range [$maxDelta,-${maxDelta}] - setting noise=Heavy"
     noiseSend=4

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1395,7 +1395,7 @@ function bt_watchdog()
     date >> $logfile
     echo "no entry.json for $minutes minutes - rebooting" | tee -a $logfile
     wall "Rebooting in 15 seconds to fix BT and xdrip-js - save your work quickly!"
-#    cd ${HOME}/myopenaps && /etc/init.d/cron stop && killall -g openaps ; killall -g oref0-pump-loop | tee -a $logfile
+    cd ${HOME}/myopenaps && /etc/init.d/cron stop && killall -g openaps ; killall -g oref0-pump-loop | tee -a $logfile
     sleep 15
     reboot
   fi


### PR DESCRIPTION
If the oref0-pump-loop plugin infrastructure exists, use it to run fakemeter so it is run in a safe spot in the loop where there will be zero pump radio collisions.