### PR TITLE
Remote address style bt device name too

### DIFF
--- a/logger/index.js
+++ b/logger/index.js
@@ -173,18 +173,25 @@ transmitter.on('glucose', glucose => {
     });
 });
 
+transmitter.on('sawTransmitter', data => {
+  const util = require('util')
+  console.log('got sawTransmitter message inside logger msg: ' + JSON.stringify(data));
+  console.log(util.inspect(data, false, null))
+
+  var fs = require('fs');
+  const battery = JSON.stringify(data);
+  fs.writeFile("/root/myopenaps/monitor/xdripjs/saw-transmitter.json", battery, function(err) {
+  if(err) {
+      console.log("Error while writing saw-transmitter.json");
+      console.log(err);
+      }
+  });
+});
 
 transmitter.on('batteryStatus', data => {
   const util = require('util')
   console.log('got batteryStatus message inside logger msg: ' + JSON.stringify(data));
   console.log(util.inspect(data, false, null))
-
-//  status: 0,
-//  voltagea: 313,
-//  voltageb: 299,
-//  resist: 848,
-//  runtime: 5,
-//  temperature: 34 
 
   var fs = require('fs');
   const battery = JSON.stringify(data);

--- a/logger/index.js
+++ b/logger/index.js
@@ -179,8 +179,8 @@ transmitter.on('sawTransmitter', data => {
   console.log(util.inspect(data, false, null))
 
   var fs = require('fs');
-  const battery = JSON.stringify(data);
-  fs.writeFile("/root/myopenaps/monitor/xdripjs/saw-transmitter.json", battery, function(err) {
+  const sawTransmitter = JSON.stringify(data);
+  fs.writeFile("/root/myopenaps/monitor/xdripjs/saw-transmitter.json", sawTransmitter, function(err) {
   if(err) {
       console.log("Error while writing saw-transmitter.json");
       console.log(err);

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -555,6 +555,7 @@ function  remove_dexcom_bt_pair()
       smac=${mac//:/-}
       smac=${smac^^}
       #echo $smac
+      log "Removing existing Dexcom bluetooth mac connection also = ${smac}"
       bt-device -r $smac 2> /dev/null
     fi
   fi

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -543,6 +543,21 @@ function  remove_dexcom_bt_pair()
 {
   log "Removing existing Dexcom bluetooth connection = ${id}"
   bt-device -r $id 2> /dev/null
+
+  # Try
+  sfile="${LDIR}/saw-transmitter.json"
+
+  if [ -e $sfile ]; then
+    mac=$(cat $sfile | jq -M '.address')
+    mac="${mac%\"}"
+    mac="${mac#\"}"
+    if [ ${#mac} -ge 8 ]; then
+      smac=${mac//:/-}
+      smac=${smac^^}
+      #echo $smac
+      bt-device -r $smac 2> /dev/null
+    fi
+  fi
 }
 
 function initialize_messages()

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -544,7 +544,7 @@ function  remove_dexcom_bt_pair()
   log "Removing existing Dexcom bluetooth connection = ${id}"
   bt-device -r $id 2> /dev/null
 
-  # Try
+  # Also remove the mac address tx pairing if exists 
   sfile="${LDIR}/saw-transmitter.json"
 
   if [ -e $sfile ]; then


### PR DESCRIPTION
If the mac address for the transmitter is paired with the rig via bluetooth, these changes will remote it as well so that Logger can start fresh with a new pairing each time regardless if the pairing occurred with DexcomXX or the mac address.