### PR TITLE
Remove false disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Join the chat at https://gitter.im/thebookins/xdrip-js](https://badges.gitter.im/thebookins/xdrip-js.svg)](https://gitter.im/thebookins/xdrip-js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 *Please note this project is neither created nor backed by Dexcom, Inc.*
+*Logger is not a product. Logger comes with no warranty or official support. Anyone using Logger is doing so at their own risk and must take responsibility for their own safety. The use of Logger for therapy is not FDA approved and comes with inherent risks.*
 
 Logger is a Bash (shell) based Dexcom g5 / g6 glucose pre-processor for OpenAPS. Logger runs on the OpenAPS rig and connects to the g5 or g6 transmitter via bluetooth, waits for the first bg, logs a json entry record, processes the entry record based on calibrations, updates NightScout and OpenAPS indepently, then exits. Logger is a wrapper shell script to xdrip-js that is called from cron every minute. The user interface is a mixture between unix command line scripts and NightScout. The current Logger features are below:
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Logger LSR calibration is a new feature as of Feb/2018. Only those who closely m
 
 [![Join the chat at https://gitter.im/thebookins/xdrip-js](https://badges.gitter.im/thebookins/xdrip-js.svg)](https://gitter.im/thebookins/xdrip-js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-*Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
+*Please note this project is neither created nor backed by Dexcom, Inc.*
 ## Prerequisites
 * Openaps must be installed using the CGM method of xdrip.
 * Logger does not currently support token-based authentication with Nightscout

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/thebookins/xdrip-js](https://badges.gitter.im/thebookins/xdrip-js.svg)](https://gitter.im/thebookins/xdrip-js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-*Please note this project is neither created nor backed by Dexcom, Inc. This software is not intended for use in therapy.*
+*Please note this project is neither created nor backed by Dexcom, Inc.*
 
 Logger is a Bash (shell) based Dexcom g5 / g6 glucose pre-processor for OpenAPS. Logger runs on the OpenAPS rig and connects to the g5 or g6 transmitter via bluetooth, waits for the first bg, logs a json entry record, processes the entry record based on calibrations, updates NightScout and OpenAPS indepently, then exits. Logger is a wrapper shell script to xdrip-js that is called from cron every minute. The user interface is a mixture between unix command line scripts and NightScout. The current Logger features are below:
 


### PR DESCRIPTION
The claim that Logger is not intended for therapy is untrue.  As evidenced by all of the other documentation, and all of the public conversations around its development, it *is* intended for use with OpenAPS, as part of a DIY artificial insulin delivery system self-built by the user.  Neither Logger nor OpenAPS is distributed as a product, but rather as source code protected under the first amendment to the US constitution.

If you want a strong disclaimer, you could point out that Logger is not a product, comes with no warranty or official support, that anyone using it is doing so at their own risk and must take responsibility for their own safety, and that use of Logger for therapy is not FDA approved and comes with inherent risks.