### PR TITLE
added environment check for bt-device

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -291,6 +291,9 @@ function check_environment
      post_cgm_ns_pill
      exit
   fi
+
+  type bt-device 2> /dev/null || echo "Error: bt-device is not found. Use sudo apt-get install bluez-tools"
+
 }
 
 function ClearCalibrationInput()


### PR DESCRIPTION
Give appropriate error and instructions if bt-device (bluez-tools) is not installed.