### PR TITLE
Change filtered/unfiltered variation max to 30

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1390,10 +1390,10 @@ function calculate_noise()
     fi
   fi
 
-  if [ $(bc <<< "$variation >= 20") -eq 1 -o  $(bc  <<< "$variation <= -20") -eq 1 ]; then
+  if [ $(bc <<< "$variation >= 30") -eq 1 -o  $(bc  <<< "$variation <= -30") -eq 1 ]; then
       noiseSend=4  
       noiseString="Heavy"
-      log "setting noise to heavy because - filtered/unfiltered variation of $variation exceeds 20%"
+      log "setting noise to heavy because - filtered/unfiltered variation of $variation exceeds 30%"
   fi
 
   tmp=$(mktemp)


### PR DESCRIPTION
My logs showed 3 cases where filtered / unfiltered variation of up to 30% was normal. There were cases with carb intake where the bg is rising that are legit and are loopable and should not be considered heavy noise.