### PR TITLE
clear calibration for 15 minutes from any Sensor Stop, Start, or Insert

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -546,6 +546,34 @@ function check_sensor_change()
     log "exiting"
     exit
   fi
+
+  curl --compressed -m 30 -H "API-SECRET: ${API_SECRET}" "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" --iso-8601=seconds $UTC)&find\[eventType\]\[\$regex\]=Sensor.Stop" 2>/dev/null | grep "Sensor Stop"
+  if [ $? == 0 ]; then
+    log "sensor stopped within last 15 minutes - clearing calibration files"
+    ClearCalibrationInput
+    ClearCalibrationCache
+    touch ${LDIR}/last_sensor_change
+    state_id=0x02
+    state="Warmup" ; stateString=$state ; stateStringShort=$state
+    post_cgm_ns_pill
+
+    log "exiting"
+    exit
+  fi
+
+  curl --compressed -m 30 -H "API-SECRET: ${API_SECRET}" "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" --iso-8601=seconds $UTC)&find\[eventType\]\[\$regex\]=Sensor.Start" 2>/dev/null | grep "Sensor Start"
+  if [ $? == 0 ]; then
+    log "sensor starl within last 15 minutes - clearing calibration files"
+    ClearCalibrationInput
+    ClearCalibrationCache
+    touch ${LDIR}/last_sensor_change
+    state_id=0x02
+    state="Warmup" ; stateString=$state ; stateStringShort=$state
+    post_cgm_ns_pill
+
+    log "exiting"
+    exit
+  fi
 }
 
 function check_last_entry_values()

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -563,7 +563,7 @@ function check_sensor_change()
 
   curl --compressed -m 30 -H "API-SECRET: ${API_SECRET}" "${NIGHTSCOUT_HOST}/api/v1/treatments.json?find\[created_at\]\[\$gte\]=$(date -d "15 minutes ago" --iso-8601=seconds $UTC)&find\[eventType\]\[\$regex\]=Sensor.Start" 2>/dev/null | grep "Sensor Start"
   if [ $? == 0 ]; then
-    log "sensor starl within last 15 minutes - clearing calibration files"
+    log "sensor start within last 15 minutes - clearing calibration files"
     ClearCalibrationInput
     ClearCalibrationCache
     touch ${LDIR}/last_sensor_change


### PR DESCRIPTION
Logger will clear all calibration cache files within 15 minutes of any Sensor Stop, Start, or Insert. This is a first step safety change. The next step will be to change Logger's calibration logic to match Lookout's and to process a new Treatment type (that doesn't exist yet) from NS called Sensor Restart.