### PR TITLE
Support for new g6 firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,12 @@ If timing out, recheck the configuration of the transmitter id, make sure the bt
 
 Since the timer only allows communications for a few seconds every 5 minutes, isolation of any timeout issues are key.  The following are some suggestions:
 1) Turn off Logger and receiver, run Xdrip+ and see if it can connect to the tx. If Xdrip+ can connect, then it may be a rig issue. If Xdrip+ cannot connect, then it's mostly isolated to a tx issue. 
-2) Check your network log. BT PAN may be trying to do something and restarting bluetoothd. Check /var/log/openaps/network.log and any bluetooth log (if it exists) in that directory. Also, check for bluetooth errors in /var/log/syslog as well.
-3) Turn off every other possible dexcom connection and try connecting with the tx with the official Dexcom app. This will only work if you have a non-expired tx or have successfully reset it earlier.
-4) Try a different transmitter (if you have one). If this works, then the other tx has an issue, usually battery related.
-5) Try a different rig (if you have one). If this works, then the other rig or it's install/configuration is likely the culprit.
+2) Run the following command. If it fails for any reason, then the install of bluez-tools may have an issue. If bluez-tools is not installed, then bt timeouts will likely be the result. ```bt-device -l```
+3) Check your network log. BT PAN may be trying to do something and restarting bluetoothd. Check /var/log/openaps/network.log and any bluetooth log (if it exists) in that directory. Also, check for bluetooth errors in /var/log/syslog as well.
+4) Turn off every other possible dexcom connection and try connecting with the tx with the official Dexcom app. This will only work if you have a non-expired tx or have successfully reset it earlier.
+5) Try a different transmitter (if you have one). If this works, then the other tx has an issue, usually battery related.
+6) Try a different rig (if you have one). If this works, then the other rig or it's install/configuration is likely the culprit.
+7) If on an RPI, check the mode in /etc/bluetooth/main.conf. At least one user found that setting mode to Controller mode resolved the timeouts. 
 
 If you have network connectivity on the rig, but BG values are not showing up on NightScout, then run the following command which should retrieve the last BG Check Treatment posted to NightScout. Review any errors that the command returns and re-check your NIGHTSCOUT_HOST and API_SECRET environment variables.
 ``` 

--- a/test/validBG.sh
+++ b/test/validBG.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+function log()
+{
+  echo $1
+}
+
+
+function validNumber()
+{
+  local num=$1
+  case ${num#[-+]} in
+    *[!0-9.]* | '') echo false ;;
+    * ) echo true ;;
+  esac
+}
+
+
+function validBG()
+{
+  local bg=$1
+  local valid="false"
+
+  if [ "$(validNumber $bg)" == "true" ]; then
+    if [ $(bc  -l <<< "$bg >= 20") -eq 1 -a $(bc -l <<< "$bg < 500") -eq 1 ]; then
+      valid="true"
+    fi
+  fi
+  
+  echo $valid
+}
+
+LDIR=~/myopenaps/monitor/xdripjs
+#unfiltered=110
+filtered=111
+raw=$unfiltered
+epochdate=$(date +'%s')
+
+
+
+#unfiltered=$(cat ${LDIR}/entry.json | jq -M '.[0].uknfiltered')
+#unfiltered=$(bc -l <<< "scale=0; $unfiltered / 1000")
+
+
+b=111
+if [ "$(validBG $b)" == "true" ]; then
+  echo "$b=valid"
+else
+  echo "$b=invalid"
+fi
+
+b=611
+if [ "$(validBG $b)" == "true" ]; then
+  echo "$b=valid"
+else
+  echo "$b=invalid"
+fi
+
+#echo "unfiltered=$unfiltered"
+
+echo "validBG undefined($fkiltered)=$(validBG $fkiltered)"
+
+filtered="what"
+echo "validBG $filtered=$(validBG $filtered)"
+
+filtered=111
+echo "validBG $filtered=$(validBG $filtered)"
+
+filtered=511
+echo "validBG $filtered=$(validBG $filtered)"
+
+filtered=111.000
+echo "validBG $filtered=$(validBG $filtered)"
+
+filtered=
+echo "validBG $filtered=$(validBG $filtered)"
+
+filtered=11
+echo "validBG $filtered=$(validBG $filtered)"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -741,7 +741,7 @@ function check_tx_calibration()
     return
   fi
 
-  # TODO: remove - not necessary anymore
+  # TODO: remove - it is likely not necessary anymore
   if [[ "$sentLoggerCalibrationToTx" == true ]]; then
     # This is the reflection of the cmd line based calibration. 
     # Do not process it twice
@@ -1092,7 +1092,6 @@ function  capture_entry_values()
   log "sessionStartDate=$sessionStartDate, sessionStartDateEpochms=$sessionStartDateEpochms" 
   log "sessionMinutesRemaining=$sessionMinutesRemaining"
   if [ $(bc <<< "$sessionMinutesRemaining < 65") -eq 1 ]; then
-    #TODO use parameter to do this only if auto-restart is true
     if [ $(bc <<< "$glucose < 400") -eq 1  -a $(bc <<< "$glucose > 40") -eq 1 ]; then
       if [ $(bc <<< "$variation < 10") -eq 1 ]; then
         if [[ "$auto_sensor_restart" == true ]]; then

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -224,6 +224,22 @@ main()
   echo
 }
 
+function validBG()
+{
+  local bg=$1
+
+  if [ "$bg" == "null" -o "$bg" == "" ]; then
+    echo false
+  else
+    if [ $(bc  -l <<< "$bg < 20") -eq 1 -o $(bc -l <<< "$bg > 500") -eq 1 ]; then
+      echo false
+    else
+      echo true
+    fi
+  fi
+}
+
+
 function check_dirs() {
 
   if [ ! -d ${LDIR} ]; then
@@ -1011,7 +1027,8 @@ function  call_logger()
     unfiltered=$(cat ${LDIR}/entry.json | jq -M '.[0].unfiltered')
     unfiltered=$(bc -l <<< "scale=0; $unfiltered / 1000")
     if [ $(bc  -l <<< "$unfiltered < 20") -eq 1 -o $(bc -l <<< "$unfiltered > 500") -eq 1 ]; then 
-      error="Invalid response - Unfiltered = $unfiltered"
+    if [ "$(validBG $unfiltered)" == "false" -a "$(validBG $glucose)" == "false" ]; then
+      error="Invalid response - Unf=$unfiltered, gluc=$glucose"
       state_id=0x25
       ls -al ${LDIR}/entry.json
       cat ${LDIR}/entry.json

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1026,7 +1026,6 @@ function  call_logger()
     glucose=$(cat ${LDIR}/entry.json | jq -M '.[0].glucose')
     unfiltered=$(cat ${LDIR}/entry.json | jq -M '.[0].unfiltered')
     unfiltered=$(bc -l <<< "scale=0; $unfiltered / 1000")
-    if [ $(bc  -l <<< "$unfiltered < 20") -eq 1 -o $(bc -l <<< "$unfiltered > 500") -eq 1 ]; then 
     if [ "$(validBG $unfiltered)" == "false" -a "$(validBG $glucose)" == "false" ]; then
       error="Invalid response - Unf=$unfiltered, gluc=$glucose"
       state_id=0x25


### PR DESCRIPTION
- fix last entry timing issue that caused some missed readings while offline
- support auto tx restarts by age based upon 7 days for g5 and 10 days for g6
- support new g6 firmware by not exiting if unfiltered is null and glucose value is valid