### PR TITLE
Node installer update

### DIFF
--- a/bin/upgrade-node.sh
+++ b/bin/upgrade-node.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This script will upgrade node to v8 if not already on that version
+# This script will upgrade node to v8 if not already at least on that version
 #
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -15,20 +15,16 @@ die() {
   exit 1
 }
 
-#install/upgrade to node 8
-if ! nodejs --version | grep 'v8.'; then
-    echo "Node version not at v8 - upgrading ..."
-    if grep -qa "Explorer HAT" /proc/device-tree/hat/product &>/dev/null ; then
-        mkdir $HOME/src/node && cd $HOME/src/node
-        wget https://nodejs.org/dist/v8.10.0/node-v8.10.0-linux-armv6l.tar.xz
-        tar -xf node-v8.10.0-linux-armv6l.tar.xz || die "Couldn't extract Node"
-        cd *6l && sudo cp -R * /usr/local/ || die "Couldn't copy Node to /usr/local"
-    else
-        sudo bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -" || die "Couldn't setup
- node 8" 
-        sudo apt-get install -y nodejs || die "Couldn't install nodejs" 
-    fi
+#install/upgrade to latest node 8 if neither node 8 nor node 10+ LTS are installed
+if ! nodejs --version | grep -e 'v8\.' -e 'v1[02468]\.' &> /dev/null ; then
+        echo "Node version not at v8 - upgrading ..."
+        if ! uname -a | grep -e 'armv6' &> /dev/null ; then
+            sudo bash -c "curl -sL https://deb.nodesource.com/setup_8.x | bash -" || die "Couldn't setup node 8"
+            sudo apt-get install -y nodejs=8.* || die "Couldn't install nodejs"
+        else
+            sudo apt-get install -y nodejs npm || die "Couldn't install nodejs and npm"
+            npm install npm@latest -g || die "Couldn't update npm"
+        fi
 else
     echo "Node version already at v8 - good to go"
 fi
-


### PR DESCRIPTION
Switches the node.js installer script to use the latest one from oref0, which will prefer packaged debian version of node (>v8 on stretch & buster).