### PR TITLE
For new g6 firmware - clear LSR cache on any sensor stop or start

### DIFF
--- a/bin/g5-version.sh
+++ b/bin/g5-version.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-MESSAGE="${HOME}/myopenaps/monitor/xdripjs/cgm-reset.json"
+MESSAGE="${HOME}/myopenaps/monitor/xdripjs/cgm-version.json"
 epochdate=$(date +'%s%3N')
 
 echo "Requesting the Dexcom Transmitter version number"

--- a/logger/index.js
+++ b/logger/index.js
@@ -229,6 +229,21 @@ transmitter.on('batteryStatus', data => {
   });
 });
 
+transmitter.on('version', data => {
+  const util = require('util')
+  console.log('got version message inside logger msg: ' + JSON.stringify(data));
+  console.log(util.inspect(data, false, null))
+
+  var fs = require('fs');
+  const version = JSON.stringify(data);
+  fs.writeFile("/root/myopenaps/monitor/xdripjs/tx-version.json", version, function(err) {
+  if(err) {
+      console.log("Error while writing tx-version.json");
+      console.log(err);
+      }
+  });
+});
+
 transmitter.on('disconnect', process.exit);
 
 transmitter.on('messageProcessed', data => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Logger",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Logger xdrip openaps",
   "main": "logger/index.js",
   "license": "MIT",

--- a/test/newFirmware.sh
+++ b/test/newFirmware.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+#private static final ImmutableSet<String> KNOWN_G5_FIRMWARES = ImmutableSet.of("1.0.0.13", "1.0.0.17", "1.0.4.10", "1.0.4.12");
+#    private static final ImmutableSet<String> KNOWN_G6_FIRMWARES = ImmutableSet.of("1.6.5.23", "1.6.5.25", "1.6.5.27");
+#    private static final ImmutableSet<String> KNOWN_G6_REV2_FIRMWARES = ImmutableSet.of("2.18.2.67", "2.18.2.88");
+#    private static final ImmutableSet<String> KNOWN_TIME_TRAVEL_TESTED = ImmutableSet.of("1.6.5.25");
+
+function newFirmware()
+{
+  case $version in
+    1.6.5.27 | 2.*)
+      echo true 
+      ;;
+    *)
+      echo false 
+      ;;
+  esac
+}
+
+version="1.6.5.27"
+if [ "$(newFirmware)" == "true" ]; then
+  echo "$version is new firmware"
+else
+  echo "$version is not new firmware"
+fi
+
+
+version="2.18.2.88"
+if [ "$(newFirmware)" == "true" ]; then
+  echo "$version is new firmware"
+else
+  echo "$version is not new firmware"
+fi
+
+version="1.0.0.17" 
+if [ "$(newFirmware)" == "true" ]; then
+  echo "$version is new firmware"
+else
+  echo "$version is not new firmware"
+fi
+
+version=""
+if [ "$(newFirmware)" == "true" ]; then
+  echo "$version is new firmware"
+else
+  echo "$version is not new firmware"
+fi
+
+version="1.6.5.25"
+if [ "$(newFirmware)" == "true" ]; then
+  echo "$version is new firmware"
+else
+  echo "$version is not new firmware"
+fi
+
+

--- a/test/newFirmware.sh
+++ b/test/newFirmware.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-#private static final ImmutableSet<String> KNOWN_G5_FIRMWARES = ImmutableSet.of("1.0.0.13", "1.0.0.17", "1.0.4.10", "1.0.4.12");
-#    private static final ImmutableSet<String> KNOWN_G6_FIRMWARES = ImmutableSet.of("1.6.5.23", "1.6.5.25", "1.6.5.27");
-#    private static final ImmutableSet<String> KNOWN_G6_REV2_FIRMWARES = ImmutableSet.of("2.18.2.67", "2.18.2.88");
-#    private static final ImmutableSet<String> KNOWN_TIME_TRAVEL_TESTED = ImmutableSet.of("1.6.5.25");
+#KNOWN_G5_FIRMWARES = ("1.0.0.13", "1.0.0.17", "1.0.4.10", "1.0.4.12");
+#KNOWN_G6_FIRMWARES = ("1.6.5.23", "1.6.5.25", "1.6.5.27");
+#KNOWN_G6_REV2_FIRMWARES = ("2.18.2.67", "2.18.2.88");
+#KNOWN_TIME_TRAVEL_TESTED = ("1.6.5.25");
 
 function newFirmware()
 {
+  local version=$1
   case $version in
     1.6.5.27 | 2.*)
       echo true 
@@ -18,7 +19,7 @@ function newFirmware()
 }
 
 version="1.6.5.27"
-if [ "$(newFirmware)" == "true" ]; then
+if [ "$(newFirmware $version)" == "true" ]; then
   echo "$version is new firmware"
 else
   echo "$version is not new firmware"
@@ -26,28 +27,28 @@ fi
 
 
 version="2.18.2.88"
-if [ "$(newFirmware)" == "true" ]; then
+if [ "$(newFirmware $version)" == "true" ]; then
   echo "$version is new firmware"
 else
   echo "$version is not new firmware"
 fi
 
 version="1.0.0.17" 
-if [ "$(newFirmware)" == "true" ]; then
+if [ "$(newFirmware $version)" == "true" ]; then
   echo "$version is new firmware"
 else
   echo "$version is not new firmware"
 fi
 
 version=""
-if [ "$(newFirmware)" == "true" ]; then
+if [ "$(newFirmware $version)" == "true" ]; then
   echo "$version is new firmware"
 else
   echo "$version is not new firmware"
 fi
 
 version="1.6.5.25"
-if [ "$(newFirmware)" == "true" ]; then
+if [ "$(newFirmware $version)" == "true" ]; then
   echo "$version is new firmware"
 else
   echo "$version is not new firmware"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1837,8 +1837,6 @@ function check_messages()
       ClearCalibrationInput
       ClearCalibrationCache
     fi
-    ClearCalibrationInput
-    ClearCalibrationCache
     #TODO: add cmd line treatments to NS
 
     # wait to remove command line file after call_logger (Tx/Rx processing)

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -503,7 +503,6 @@ function check_sensor_stop()
           echo "Already Processed Sensor Stop Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
           # Always clear LSR cache for any g6 start / stop
           if [ "$txType" == "g6" ]; then
-            sessionMaxSeconds=$SECONDS_IN_7_DAYS
             ClearCalibrationInput
             ClearCalibrationCache
           fi
@@ -548,7 +547,6 @@ function check_sensor_start()
           echo "Already Processed Sensor Start Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
           # Always clear LSR cache for any g6 start / stop
           if [ "$txType" == "g6" ]; then
-            sessionMaxSeconds=$SECONDS_IN_7_DAYS
             ClearCalibrationInput
             ClearCalibrationCache
           fi
@@ -1824,7 +1822,6 @@ function check_messages()
     log "stopJSON=$stopJSON"
     # Always clear LSR cache for any g6 start / stop
     if [ "$txType" == "g6" ]; then
-      sessionMaxSeconds=$SECONDS_IN_7_DAYS
       ClearCalibrationInput
       ClearCalibrationCache
     fi
@@ -1837,7 +1834,6 @@ function check_messages()
     log "startJSON=$startJSON"
     # Always clear LSR cache for any g6 start / stop
     if [ "$txType" == "g6" ]; then
-      sessionMaxSeconds=$SECONDS_IN_7_DAYS
       ClearCalibrationInput
       ClearCalibrationCache
     fi

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -501,9 +501,12 @@ function check_sensor_stop()
           echo "stopJSON = $stopJSON"
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Stop Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
-          # Always clear LSR cache for any start / stop
-          ClearCalibrationInput
-          ClearCalibrationCache
+          # Always clear LSR cache for any g6 start / stop
+          if [ "$txType" == "g6" ]; then
+            sessionMaxSeconds=$SECONDS_IN_7_DAYS
+            ClearCalibrationInput
+            ClearCalibrationCache
+          fi
         fi
       fi
     fi
@@ -543,9 +546,12 @@ function check_sensor_start()
           echo "startJSON = $startJSON"
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Start Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
-          # Always clear LSR cache for any start / stop
-          ClearCalibrationInput
-          ClearCalibrationCache
+          # Always clear LSR cache for any g6 start / stop
+          if [ "$txType" == "g6" ]; then
+            sessionMaxSeconds=$SECONDS_IN_7_DAYS
+            ClearCalibrationInput
+            ClearCalibrationCache
+          fi
   
           #update xdripjs.json with new sensor code
           if [ "$sensorSerialCode" != "null" -a "$sensorSerialCode" != "" ]; then  
@@ -1816,9 +1822,12 @@ function check_messages()
   if [ -e "$cgm_stop_file" ]; then
     stopJSON=$(cat $cgm_stop_file)
     log "stopJSON=$stopJSON"
-    # Always clear LSR cache for any start / stop
-    ClearCalibrationInput
-    ClearCalibrationCache
+    # Always clear LSR cache for any g6 start / stop
+    if [ "$txType" == "g6" ]; then
+      sessionMaxSeconds=$SECONDS_IN_7_DAYS
+      ClearCalibrationInput
+      ClearCalibrationCache
+    fi
     # wait to remove command line file after call_logger (Tx/Rx processing)
   fi
 
@@ -1826,7 +1835,12 @@ function check_messages()
   if [ -e "$cgm_start_file" ]; then
     startJSON=$(cat $cgm_start_file)
     log "startJSON=$startJSON"
-    # Always clear LSR cache for any start / stop
+    # Always clear LSR cache for any g6 start / stop
+    if [ "$txType" == "g6" ]; then
+      sessionMaxSeconds=$SECONDS_IN_7_DAYS
+      ClearCalibrationInput
+      ClearCalibrationCache
+    fi
     ClearCalibrationInput
     ClearCalibrationCache
     #TODO: add cmd line treatments to NS

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1071,6 +1071,20 @@ function  call_logger()
   fi
 }
 
+function newFirmware()
+{
+  local version=$1
+  case $version in
+    1.6.5.27 | 2.*)
+      echo true 
+      ;;
+    *)
+      echo false 
+      ;;
+  esac
+}
+
+
 function  capture_entry_values()
 {
   # capture values for use and for log to csv file 
@@ -1093,7 +1107,11 @@ function  capture_entry_values()
     tx_version=$(cat ${LDIR}/tx-version.json | jq -M '.firmwareVersion')
     tx_version="${tx_version%\"}"
     tx_version="${tx_version#\"}"
-    log "tx_version=$tx_version" 
+    if [ "$(newFirmware $tx_version)" == "true" ]; then
+      echo "tx $tx_version is new firmware"
+    else
+      echo "tx $tx_version is not new firmware"
+    fi
   fi
 
   transmitterStartDate="${transmitterStartDate%\"}"

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -502,7 +502,7 @@ function check_sensor_stop()
           echo "stopJSON = $stopJSON"
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Stop Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
-          # Always clear LSR cache for any g6 start / stop
+          # Always clear LSR cache for any new firmware g6 start / stop
           if [ "$(newFirmware $tx_version)" == "true" ]; then
             ClearCalibrationInput
             ClearCalibrationCache
@@ -546,7 +546,7 @@ function check_sensor_start()
           echo "startJSON = $startJSON"
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Start Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
-          # Always clear LSR cache for any g6 start / stop
+          # Always clear LSR cache for any new firmware g6 start / stop
           if [ "$(newFirmware $tx_version)" == "true" ]; then
             ClearCalibrationInput
             ClearCalibrationCache
@@ -1852,7 +1852,7 @@ function check_messages()
   if [ -e "$cgm_stop_file" ]; then
     stopJSON=$(cat $cgm_stop_file)
     log "stopJSON=$stopJSON"
-    # Always clear LSR cache for any g6 start / stop
+    # Always clear LSR cache for any new firmware g6 start / stop
     if [ "$(newFirmware $tx_version)" == "true" ]; then
       ClearCalibrationInput
       ClearCalibrationCache
@@ -1864,7 +1864,7 @@ function check_messages()
   if [ -e "$cgm_start_file" ]; then
     startJSON=$(cat $cgm_start_file)
     log "startJSON=$startJSON"
-    # Always clear LSR cache for any g6 start / stop
+    # Always clear LSR cache for any new firmware g6 start / stop
     if [ "$(newFirmware $tx_version)" == "true" ]; then
       ClearCalibrationInput
       ClearCalibrationCache

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -503,7 +503,7 @@ function check_sensor_stop()
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Stop Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
           # Always clear LSR cache for any g6 start / stop
-          if [ "$txType" == "g6" ]; then
+          if [ "$(newFirmware $tx_version)" == "true" ]; then
             ClearCalibrationInput
             ClearCalibrationCache
           fi
@@ -547,7 +547,7 @@ function check_sensor_start()
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Start Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
           # Always clear LSR cache for any g6 start / stop
-          if [ "$txType" == "g6" ]; then
+          if [ "$(newFirmware $tx_version)" == "true" ]; then
             ClearCalibrationInput
             ClearCalibrationCache
           fi
@@ -1853,7 +1853,7 @@ function check_messages()
     stopJSON=$(cat $cgm_stop_file)
     log "stopJSON=$stopJSON"
     # Always clear LSR cache for any g6 start / stop
-    if [ "$txType" == "g6" ]; then
+    if [ "$(newFirmware $tx_version)" == "true" ]; then
       ClearCalibrationInput
       ClearCalibrationCache
     fi
@@ -1865,7 +1865,7 @@ function check_messages()
     startJSON=$(cat $cgm_start_file)
     log "startJSON=$startJSON"
     # Always clear LSR cache for any g6 start / stop
-    if [ "$txType" == "g6" ]; then
+    if [ "$(newFirmware $tx_version)" == "true" ]; then
       ClearCalibrationInput
       ClearCalibrationCache
     fi

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1108,9 +1108,9 @@ function  capture_entry_values()
     tx_version="${tx_version%\"}"
     tx_version="${tx_version#\"}"
     if [ "$(newFirmware $tx_version)" == "true" ]; then
-      echo "tx $tx_version is new firmware"
+      echo "Dexcom tx version is $tx_version (new firmware)"
     else
-      echo "tx $tx_version is not new firmware"
+      echo "Dexcom tx version is $tx_version (not new firmware)"
     fi
   fi
 

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -501,6 +501,9 @@ function check_sensor_stop()
           echo "stopJSON = $stopJSON"
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Stop Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
+          # Always clear LSR cache for any start / stop
+          ClearCalibrationInput
+          ClearCalibrationCache
         fi
       fi
     fi
@@ -540,8 +543,9 @@ function check_sensor_start()
           echo "startJSON = $startJSON"
           # below done so that next time the egrep returns positive for this specific message and the log reads right
           echo "Already Processed Sensor Start Message from Nightscout at $createdAt" >> ${LDIR}/nightscout-treatments.log
-          # do not clear in this case because in session sensors could be just doing a quick start 
-          # clearing only happens for sensor insert
+          # Always clear LSR cache for any start / stop
+          ClearCalibrationInput
+          ClearCalibrationCache
   
           #update xdripjs.json with new sensor code
           if [ "$sensorSerialCode" != "null" -a "$sensorSerialCode" != "" ]; then  
@@ -1812,6 +1816,9 @@ function check_messages()
   if [ -e "$cgm_stop_file" ]; then
     stopJSON=$(cat $cgm_stop_file)
     log "stopJSON=$stopJSON"
+    # Always clear LSR cache for any start / stop
+    ClearCalibrationInput
+    ClearCalibrationCache
     # wait to remove command line file after call_logger (Tx/Rx processing)
   fi
 
@@ -1819,6 +1826,9 @@ function check_messages()
   if [ -e "$cgm_start_file" ]; then
     startJSON=$(cat $cgm_start_file)
     log "startJSON=$startJSON"
+    # Always clear LSR cache for any start / stop
+    ClearCalibrationInput
+    ClearCalibrationCache
     #TODO: add cmd line treatments to NS
 
     # wait to remove command line file after call_logger (Tx/Rx processing)

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -402,10 +402,9 @@ function ClearCalibrationInputOne()
 
 function ClearCalibrationCache()
 {
-  local cache="$calibrationFile"
-  if [ -e ${LDIR}/$cache ]; then
-    cp ${LDIR}/$cache "${LDIR}/old-calibrations/${cache}.$(date +%Y%m%d-%H%M%S)" 
-    rm ${LDIR}/$cache 
+  if [ -e $calibrationFile ]; then
+    cp $calibrationFile "${LDIR}/old-calibrations/calibration-linear.$(date +%Y%m%d-%H%M%S)" 
+    rm $calibrationFile 
   fi
 }
 
@@ -1588,9 +1587,8 @@ function post_cgm_ns_pill()
 {
    # json required conversion to decimal values
 
-   local cache="$calibrationFile"
-   if [ -e $cache ]; then
-     lastCalibrationDate=$(stat -c "%Y000" ${cache})
+   if [ -e $calibrationFile ]; then
+     lastCalibrationDate=$(stat -c "%Y000" ${calibrationFile})
    fi
 
    # Dont send tx activation date to NS CGM pill if state is invalid

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -470,7 +470,7 @@ function check_send_battery_status()
        touch $file 
        battery_date=$(date +'%s%3N')
        batteryJSON="[{\"date\": ${battery_date}, \"type\": \"BatteryStatus\"}]"
-       batteryJSON="[{\"date\": ${battery_date}, \"type\": \"VersionRequest\"}]"
+       versionJSON="[{\"date\": ${battery_date}, \"type\": \"VersionRequest\"}]"
        log "Sending Message to Transmitter to request battery and version status"
    fi
  }

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -470,7 +470,8 @@ function check_send_battery_status()
        touch $file 
        battery_date=$(date +'%s%3N')
        batteryJSON="[{\"date\": ${battery_date}, \"type\": \"BatteryStatus\"}]"
-       log "Sending Message to Transmitter to request battery status"
+       batteryJSON="[{\"date\": ${battery_date}, \"type\": \"VersionRequest\"}]"
+       log "Sending Message to Transmitter to request battery and version status"
    fi
  }
 
@@ -977,12 +978,17 @@ function initialize_messages()
   startJSON=""
   batteryJSON=""
   resetJSON=""
+  versionJSON=""
 }
 
 function compile_messages()
 {
   if [ "${resetJSON}" != "" ]; then
     addToMessages "$resetJSON" $xdripMessageFile
+  fi
+
+  if [ "${versionJSON}" != "" ]; then
+    addToMessages "$versionJSON" $xdripMessageFile
   fi
 
   if [ "${stopJSON}" != "" ]; then
@@ -1846,6 +1852,13 @@ function check_messages()
   if [ -e "$file" ]; then
     resetJSON=$(cat $file)
     log "resetJSON=$resetJSON"
+    rm -f $file
+  fi
+
+  file="${LDIR}/cgm-version.json"
+  if [ -e "$file" ]; then
+    resetJSON=$(cat $file)
+    log "versionJSON=$versionJSON"
     rm -f $file
   fi
 }

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1088,6 +1088,14 @@ function  capture_entry_values()
   state_id=$(cat ${LDIR}/extra.json | jq -M '.[0].state_id')
   status_id=$(cat ${LDIR}/extra.json | jq -M '.[0].status_id')
   transmitterStartDate=$(cat ${LDIR}/extra.json | jq -M '.[0].transmitterStartDate')
+
+  if [ -e "${LDIR}/tx-version.json" ]; then
+    tx_version=$(cat ${LDIR}/tx-version.json | jq -M '.firmwareVersion')
+    tx_version="${tx_version%\"}"
+    tx_version="${tx_version#\"}"
+    log "tx_version=$tx_version" 
+  fi
+
   transmitterStartDate="${transmitterStartDate%\"}"
   transmitterStartDate="${transmitterStartDate#\"}"
   log "transmitterStartDate=$transmitterStartDate" 


### PR DESCRIPTION
For any new g6 firmware transmitter, always clear the LSR calibration cache completely for any sensor start or stop. This will require at least one calibration for any sensor start or restart before Logger will process any glucose values using LSR or Single Point. Otherwise, Logger will wait for official glucose records after the 2-hour warm-up period.