### PR TITLE
correct versionJSON typo

### DIFF
--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1883,7 +1883,7 @@ function check_messages()
 
   file="${LDIR}/cgm-version.json"
   if [ -e "$file" ]; then
-    resetJSON=$(cat $file)
+    versionJSON=$(cat $file)
     log "versionJSON=$versionJSON"
     rm -f $file
   fi


### PR DESCRIPTION
Correcting a typo that would cause the resetJSON request to be missed if both resetJSON and versionJSON were done in the same 5-minute interval.