### PR TITLE
Optional Logger Announcement as a Note

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ You can edit the following options values in the configuration file (~/myopenaps
 	{"watchdog":true or false}, Optional - Default is true. If set to true then Logger will automatically reboot the rig to resolve bluetooth issues if no glucose is seen from the transmitter in more than 14 minutes.
 	{"utc":true or false}, Optional - Default is true. If set to true then Logger will assume UTC date/time strings coming from the curls to NightScout. 
 	{"fakemeter_only_offline":true or false}, Optional - Default is false. If set to false then Logger will not attempt to call fakemeter unless the rig is offline. 
+	{"note_not_announcement":true or false}, Optional - Default is false. If set to true then Logger will post an Announcement as a Note. 
 
 ## Getting Started
 First, make sure you've checked the Prerequisites above and completed the Installation steps. Afterwords, perform the following steps:

--- a/xdrip-get-entries.sh
+++ b/xdrip-get-entries.sh
@@ -1267,7 +1267,14 @@ function postAnnouncementToNS()
 {
   local announcement=$1
 
-  echo "[{\"enteredBy\":\"Logger\",\"eventType\":\"Announcement\",\"notes\":\"$announcement\"}]" > ${LDIR}/status-change.json
+  note_not_announcement=$(cat ${CONF_DIR}/xdripjs.json | jq -M -r '.note_not_announcement')
+  if [ "$note_not_announcement" == true ]; then
+      eventtype="Note"
+  else
+      eventtype="Announcement"
+  fi
+
+  echo "[{\"enteredBy\":\"Logger\",\"eventType\":\"$eventtype\",\"notes\":\"$announcement\"}]" > ${LDIR}/status-change.json
   /usr/local/bin/cgm-post-ns ${LDIR}/status-change.json treatments && (echo; log "Upload to NightScout of Announcment worked - $announcement") || (echo; log "Upload of Announcement to NS did not work - $announcement")
 }
 


### PR DESCRIPTION
I have NS open as a background tab and the Logger Annoucements stop the sgv from being shown on the tab name, so to prevent this, I've put an option to have the Announcement uploaded to NS as a Note instead.

e.g.

![image](https://user-images.githubusercontent.com/37312469/108610758-0dfcdf80-73d0-11eb-8a6d-3578c45f3c0a.png)
